### PR TITLE
Expose data engine under ironforge namespace

### DIFF
--- a/ironforge/data_engine/__init__.py
+++ b/ironforge/data_engine/__init__.py
@@ -1,0 +1,36 @@
+"""Data engine utilities for IRONFORGE.
+
+This module re-exports the authoritative data engine implementation
+located in the legacy `IRONFORGE` package so that consumers can import
+`ironforge.data_engine` regardless of case. This ensures compatibility
+with existing code and tests expecting the module under the
+`ironforge` namespace.
+"""
+
+from .schemas import DTYPES, EDGE_COLS, NFEATS_EDGE, NFEATS_NODE, NODE_COLS
+
+# ``pyarrow`` is an optional dependency used by the parquet writer. Import it
+# lazily so modules that only need the schema definitions do not fail when
+# ``pyarrow`` is absent. Consumers requiring parquet functionality can import
+# ``ironforge.data_engine.parquet_writer`` directly; it will raise if
+# ``pyarrow`` is missing.
+try:  # pragma: no cover - exercised indirectly
+    from .parquet_writer import write_edges, write_nodes
+except Exception:  # ModuleNotFoundError if pyarrow isn't installed
+    # Expose stubs so attribute access fails with a helpful message
+    def write_nodes(*_, **__):  # type: ignore[override]
+        raise ImportError("pyarrow is required for parquet writing")
+
+    def write_edges(*_, **__):  # type: ignore[override]
+        raise ImportError("pyarrow is required for parquet writing")
+
+
+__all__ = [
+    "NFEATS_NODE",
+    "NFEATS_EDGE",
+    "NODE_COLS",
+    "EDGE_COLS",
+    "DTYPES",
+    "write_nodes",
+    "write_edges",
+]

--- a/ironforge/data_engine/parquet_writer.py
+++ b/ironforge/data_engine/parquet_writer.py
@@ -1,0 +1,57 @@
+"""Validated Parquet writers for nodes and edges.
+
+This implementation mirrors the original utilities but guards the
+optional ``pyarrow`` dependency so that importing the module does not
+raise when ``pyarrow`` is absent.  The actual writer functions will
+raise an informative :class:`ImportError` if used without ``pyarrow``
+installed.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+try:  # pragma: no cover - executed at import time
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+except Exception:  # pragma: no cover - pyarrow missing
+    pa = None  # type: ignore
+    pq = None  # type: ignore
+
+from .schemas import DTYPES, EDGE_COLS, NODE_COLS
+
+
+def _require_pyarrow() -> None:
+    if pa is None or pq is None:  # pragma: no cover - runtime check
+        raise ImportError("pyarrow is required for parquet writing")
+
+
+def _validate(df: pd.DataFrame, cols: list[str]) -> None:
+    """Validate that DataFrame has required columns."""
+    missing = [c for c in cols if c not in df.columns]
+    if missing:
+        raise ValueError(f"Missing columns: {missing}")
+
+
+def _cast(df: pd.DataFrame, dtypes: dict[str, str]) -> pd.DataFrame:
+    """Cast DataFrame columns to specified types."""
+    for c, t in dtypes.items():
+        if c in df.columns:
+            df[c] = df[c].astype(t, copy=False)
+    return df
+
+
+def write_nodes(df: pd.DataFrame, path: str) -> None:
+    """Write nodes DataFrame to Parquet with validation."""
+    _require_pyarrow()
+    _validate(df, NODE_COLS)
+    df = _cast(df, DTYPES)
+    pq.write_table(pa.Table.from_pandas(df, preserve_index=False), path, compression="zstd")
+
+
+def write_edges(df: pd.DataFrame, path: str) -> None:
+    """Write edges DataFrame to Parquet with validation."""
+    _require_pyarrow()
+    _validate(df, EDGE_COLS)
+    df = _cast(df, DTYPES)
+    pq.write_table(pa.Table.from_pandas(df, preserve_index=False), path, compression="zstd")

--- a/ironforge/data_engine/schemas.py
+++ b/ironforge/data_engine/schemas.py
@@ -1,0 +1,15 @@
+"""Authoritative column definitions and data types for IRONFORGE data storage."""
+
+NFEATS_NODE = 45
+NFEATS_EDGE = 20
+NODE_COLS = ["node_id", "t", "kind"] + [f"f{i}" for i in range(NFEATS_NODE)]
+EDGE_COLS = ["src", "dst", "etype", "dt"] + [f"e{i}" for i in range(NFEATS_EDGE)]
+DTYPES = {
+    "node_id": "uint32",
+    "t": "int64",
+    "kind": "uint8",
+    "src": "uint32",
+    "dst": "uint32",
+    "etype": "uint8",
+    "dt": "int32",
+}


### PR DESCRIPTION
## Summary
- add ironforge.data_engine package mirroring legacy implementation
- guard optional pyarrow dependency and provide helpful stubs
- expose schemas and parquet writer helpers under ironforge namespace

## Testing
- `pytest tests/unit/test_schemas.py`
- `pytest` *(fails: SystemExit: 1 in tests/integration/test_broad_spectrum_archaeology.py)*
- `pre-commit run --files ironforge/data_engine/__init__.py ironforge/data_engine/schemas.py ironforge/data_engine/parquet_writer.py` *(mypy skipped: source file found twice under different module names)*

------
https://chatgpt.com/codex/tasks/task_e_68a23a8c7554832398bf3d659ceca6d9