### PR TITLE
Add Parquet graph reader with validation

### DIFF
--- a/ironforge/data_engine/parquet_reader.py
+++ b/ironforge/data_engine/parquet_reader.py
@@ -1,0 +1,59 @@
+"""Validated Parquet readers for nodes and edges."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+# Only a subset of columns are required for basic graph construction.  We
+# validate these minimal sets rather than the full schemas to keep the reader
+# flexible for partial datasets.
+REQUIRED_NODE_COLS = ["node_id"]
+REQUIRED_EDGE_COLS = ["src", "dst"]
+
+
+def _validate(df: pd.DataFrame, required: list[str], kind: str) -> None:
+    """Validate that ``df`` contains the required columns."""
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        raise ValueError(f"{kind} file missing columns: {missing}")
+
+
+def read_parquet_graph(path: str | Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Read ``nodes.parquet`` and ``edges.parquet`` from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Directory containing ``nodes.parquet`` and ``edges.parquet``.
+
+    Returns
+    -------
+    tuple[pandas.DataFrame, pandas.DataFrame]
+        DataFrames for nodes and edges respectively.
+
+    Raises
+    ------
+    FileNotFoundError
+        If either ``nodes.parquet`` or ``edges.parquet`` is missing.
+    ValueError
+        If the required columns are not present in the respective files.
+    """
+
+    base = Path(path)
+    nodes_path = base / "nodes.parquet"
+    edges_path = base / "edges.parquet"
+
+    if not nodes_path.is_file():
+        raise FileNotFoundError(f"Missing nodes parquet file: {nodes_path}")
+    if not edges_path.is_file():
+        raise FileNotFoundError(f"Missing edges parquet file: {edges_path}")
+
+    nodes_df = pd.read_parquet(nodes_path)
+    edges_df = pd.read_parquet(edges_path)
+
+    _validate(nodes_df, REQUIRED_NODE_COLS, "nodes")
+    _validate(edges_df, REQUIRED_EDGE_COLS, "edges")
+
+    return nodes_df, edges_df

--- a/tests/unit/test_parquet_reader.py
+++ b/tests/unit/test_parquet_reader.py
@@ -1,0 +1,62 @@
+"""Tests for the Parquet reader utilities."""
+
+import pandas as pd
+import pytest
+from pathlib import Path
+
+from ironforge.data_engine.parquet_reader import read_parquet_graph
+
+
+def test_missing_nodes_file(tmp_path: Path) -> None:
+    """Reading should fail if ``nodes.parquet`` is absent."""
+    # Create only edges file
+    (tmp_path / "edges.parquet").touch()
+
+    with pytest.raises(FileNotFoundError) as exc:
+        read_parquet_graph(tmp_path)
+    assert "nodes.parquet" in str(exc.value)
+
+
+def test_missing_edges_file(tmp_path: Path) -> None:
+    """Reading should fail if ``edges.parquet`` is absent."""
+    (tmp_path / "nodes.parquet").touch()
+
+    with pytest.raises(FileNotFoundError) as exc:
+        read_parquet_graph(tmp_path)
+    assert "edges.parquet" in str(exc.value)
+
+
+def test_missing_node_column(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reader validates that nodes file has required column."""
+    (tmp_path / "nodes.parquet").touch()
+    (tmp_path / "edges.parquet").touch()
+
+    def fake_read(path: str | Path, *_, **__):
+        path = Path(path)
+        if path.name == "nodes.parquet":
+            return pd.DataFrame({"t": [0]})  # missing node_id
+        return pd.DataFrame({"src": [0], "dst": [1]})
+
+    monkeypatch.setattr(pd, "read_parquet", fake_read)
+
+    with pytest.raises(ValueError) as exc:
+        read_parquet_graph(tmp_path)
+    assert "node_id" in str(exc.value)
+
+
+def test_missing_edge_column(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reader validates that edges file has required columns."""
+    (tmp_path / "nodes.parquet").touch()
+    (tmp_path / "edges.parquet").touch()
+
+    def fake_read(path: str | Path, *_, **__):
+        path = Path(path)
+        if path.name == "nodes.parquet":
+            return pd.DataFrame({"node_id": [0]})
+        return pd.DataFrame({"src": [0]})  # missing dst
+
+    monkeypatch.setattr(pd, "read_parquet", fake_read)
+
+    with pytest.raises(ValueError) as exc:
+        read_parquet_graph(tmp_path)
+    assert "dst" in str(exc.value)


### PR DESCRIPTION
## Summary
- add parquet_reader that checks for nodes/edges files and required columns
- unit tests for missing files and missing columns scenarios

## Testing
- `PYTHONPATH=. pytest tests/unit/test_parquet_reader.py tests/unit/test_schemas.py -q`
- `PYTHONPATH=. pytest tests/unit/test_roundtrip_parquet_graph.py -q` *(fails: No module named 'ironforge.graph_builder')*

------
https://chatgpt.com/codex/tasks/task_e_68a25ff154488323b3f5b644a4f07548