### PR TITLE
feat: add UMAP-HDBSCAN discovery pipeline

### DIFF
--- a/ironforge/analysis/pattern_discovery.py
+++ b/ironforge/analysis/pattern_discovery.py
@@ -1,0 +1,110 @@
+"""Pattern discovery using UMAP for dimensionality reduction and HDBSCAN for clustering.
+
+This module exposes a ``discover_patterns`` helper that standardizes numeric
+features, computes UMAP embeddings, clusters the embeddings with HDBSCAN and
+derives dependency structures via mutual information and Graphical Lasso.
+
+The implementation is intentionally lightweight so it can operate on synthetic
+or real session-level features within the constraints of IRONFORGE's discovery
+workflow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import hdbscan
+import numpy as np
+import pandas as pd
+import umap
+from sklearn.covariance import GraphicalLasso
+from sklearn.feature_selection import mutual_info_regression
+from sklearn.preprocessing import StandardScaler
+
+
+@dataclass
+class DiscoveryResult:
+    """Container for outputs of :func:`discover_patterns`.
+
+    Attributes:
+        embeddings: Low-dimensional representation produced by UMAP.
+        labels: Cluster labels from HDBSCAN (``-1`` denotes noise).
+        mutual_information: Symmetric matrix of pairwise mutual information
+            between features used for discovery.
+        precision: Estimated precision (inverse covariance) matrix from the
+            Graphical Lasso model.
+    """
+
+    embeddings: np.ndarray
+    labels: np.ndarray
+    mutual_information: np.ndarray
+    precision: np.ndarray
+
+
+def _compute_mutual_information(features: np.ndarray) -> np.ndarray:
+    """Compute a symmetric mutual-information matrix for continuous features."""
+    n_features = features.shape[1]
+    mi_matrix = np.zeros((n_features, n_features))
+    for i in range(n_features):
+        for j in range(i + 1, n_features):
+            mi = mutual_info_regression(features[:, [i]], features[:, j])
+            mi_matrix[i, j] = mi[0]
+            mi_matrix[j, i] = mi[0]
+    return mi_matrix
+
+
+def discover_patterns(
+    data: pd.DataFrame | np.ndarray,
+    *,
+    n_neighbors: int = 30,
+    min_dist: float = 0.05,
+    n_components: int = 10,
+    cluster_min_size: int = 25,
+    random_state: int = 42,
+    alpha: float = 0.01,
+) -> DiscoveryResult:
+    """Run the full discovery pipeline on ``data``.
+
+    Args:
+        data: 2D array-like structure containing numeric features.
+        n_neighbors: UMAP ``n_neighbors`` parameter controlling local/global
+            balance.
+        min_dist: UMAP ``min_dist`` parameter controlling cluster tightness.
+        n_components: Target dimensionality for UMAP embeddings.
+        cluster_min_size: Minimum cluster size for HDBSCAN.
+        random_state: Random seed for reproducibility.
+        alpha: Regularisation strength for the Graphical Lasso model.
+
+    Returns:
+        :class:`DiscoveryResult` with embeddings, cluster labels, mutual
+        information matrix and precision matrix.
+    """
+    array = np.asarray(data, dtype=float)
+    if array.ndim != 2:
+        raise ValueError("data must be 2-dimensional")
+
+    scaled = StandardScaler().fit_transform(array)
+
+    reducer = umap.UMAP(
+        n_neighbors=n_neighbors,
+        min_dist=min_dist,
+        n_components=n_components,
+        metric="cosine",
+        random_state=random_state,
+    )
+    embeddings = reducer.fit_transform(scaled)
+
+    clusterer = hdbscan.HDBSCAN(min_cluster_size=cluster_min_size)
+    labels = clusterer.fit_predict(embeddings)
+
+    mi_matrix = _compute_mutual_information(scaled)
+
+    model = GraphicalLasso(alpha=alpha)
+    model.fit(scaled)
+
+    return DiscoveryResult(
+        embeddings=embeddings,
+        labels=labels,
+        mutual_information=mi_matrix,
+        precision=model.precision_,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "torch-geometric>=2.4.0",
     "matplotlib>=3.7.0",
     "seaborn>=0.12.0",
-    "scikit-learn>=1.3.0,<1.6.0",
+    "scikit-learn>=1.3.0,<1.8.0",
     "networkx>=3.0",
     "tqdm>=4.65.0",
     "PyYAML>=6.0",
@@ -39,6 +39,8 @@ dependencies = [
     "orjson>=3.9.0",
     "pyarrow>=14.0.0",
     "iron-core>=1.0.0",
+    "umap-learn>=0.5.5,<0.6.0",
+    "hdbscan>=0.8.33,<0.9.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/analysis/test_pattern_discovery.py
+++ b/tests/unit/analysis/test_pattern_discovery.py
@@ -1,0 +1,27 @@
+import importlib.util
+from pathlib import Path
+
+from sklearn.datasets import make_blobs
+
+SPEC = importlib.util.spec_from_file_location(
+    "pattern_discovery",
+    Path(__file__).resolve().parents[3] / "ironforge" / "analysis" / "pattern_discovery.py",
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+discover_patterns = MODULE.discover_patterns
+
+
+def test_discover_patterns_shapes() -> None:
+    X, _ = make_blobs(n_samples=50, n_features=6, centers=3, random_state=0)
+    result = discover_patterns(X, n_components=2, cluster_min_size=5)
+
+    assert result.embeddings.shape == (50, 2)
+    assert result.labels.shape == (50,)
+    assert result.mutual_information.shape == (6, 6)
+    assert result.precision.shape == (6, 6)
+    clusters = set(result.labels)
+    clusters.discard(-1)
+    assert len(clusters) >= 1


### PR DESCRIPTION
## Summary
- add `discover_patterns` helper using UMAP embeddings, HDBSCAN clustering, mutual information and Graphical Lasso
- test discovery pipeline on synthetic data
- include umap-learn and hdbscan as core dependencies

## Testing
- `ruff check ironforge/analysis/pattern_discovery.py tests/unit/analysis/test_pattern_discovery.py`
- `pytest tests/unit/analysis/test_pattern_discovery.py`
- `make lint` *(fails: F401 etc. across repository)*
- `make type` *(fails: existing syntax and missing stubs)*
- `make test` *(fails: iron_core.performance missing)*
- `pre-commit run --files pyproject.toml ironforge/analysis/pattern_discovery.py tests/unit/analysis/test_pattern_discovery.py` *(fails: mypy missing types, pytest-contracts import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b24cd8e4b08323bdc0c844096f4c3d